### PR TITLE
Fix association bug

### DIFF
--- a/lib/her/model/associations/association.rb
+++ b/lib/her/model/associations/association.rb
@@ -44,7 +44,6 @@ module Her
 
         # @private
         def fetch(opts = {})
-          #return default if parent attributes includes a key for the object but the value is blank and no parameters were passed in.
           return @opts[:default].try(:dup) if @parent.attributes.include?(@name) && (@parent.attributes[@name].nil? || @parent.attributes[@name].empty?) && @params.empty?
 
           if @parent.attributes[@name].blank? || @params.any?

--- a/lib/her/model/associations/association.rb
+++ b/lib/her/model/associations/association.rb
@@ -44,8 +44,7 @@ module Her
 
         # @private
         def fetch(opts = {})
-          #return default if parent is a blank object.
-          #also return default if parent attributes includes a key for the object but the value is blank and no parameters were passed in.
+          #return default if parent attributes includes a key for the object but the value is blank and no parameters were passed in.
           return @opts[:default].try(:dup) if @parent.attributes.include?(@name) && (@parent.attributes[@name].nil? || @parent.attributes[@name].empty?) && @params.empty?
 
           if @parent.attributes[@name].blank? || @params.any?

--- a/lib/her/model/associations/association.rb
+++ b/lib/her/model/associations/association.rb
@@ -44,7 +44,9 @@ module Her
 
         # @private
         def fetch(opts = {})
-          return @opts[:default].try(:dup) if @parent.attributes.include?(@name) && @parent.attributes[@name].empty? && @params.empty?
+          #return default if parent is a blank object.
+          #also return default if parent attributes includes a key for the object but the value is blank and no parameters were passed in.
+          return @opts[:default].try(:dup) if @parent.attributes.empty? || (@parent.attributes.include?(@name) && (@parent.attributes[@name].nil? || @parent.attributes[@name].empty?) && @params.empty?)
 
           if @parent.attributes[@name].blank? || @params.any?
             path = build_association_path lambda { "#{@parent.request_path(@params)}#{@opts[:path]}" }

--- a/lib/her/model/associations/association.rb
+++ b/lib/her/model/associations/association.rb
@@ -46,7 +46,7 @@ module Her
         def fetch(opts = {})
           #return default if parent is a blank object.
           #also return default if parent attributes includes a key for the object but the value is blank and no parameters were passed in.
-          return @opts[:default].try(:dup) if @parent.attributes.empty? || (@parent.attributes.include?(@name) && (@parent.attributes[@name].nil? || @parent.attributes[@name].empty?) && @params.empty?)
+          return @opts[:default].try(:dup) if @parent.attributes.include?(@name) && (@parent.attributes[@name].nil? || @parent.attributes[@name].empty?) && @params.empty?
 
           if @parent.attributes[@name].blank? || @params.any?
             path = build_association_path lambda { "#{@parent.request_path(@params)}#{@opts[:path]}" }


### PR DESCRIPTION
When editing an item that does not have a recipe, Her looks for the recipe association in the item object to determine if it needs to fetch it.  Because we're passing item: { recipe: nil }, it checks nil.empty? , which causes an error.  Changing this:

@parent.attributes[:recipe].empty?

to this: @parent.attributes[:recipe].nil? || @parent.attributes[:recipe].empty?
catches the error.

Then we have a newly instantiated recipe.  Because a recipe has_many ingredients, Her then tries to fetch the recipe's ingredients.  It checks if  @parent.attributes.include?(:ingredients).  Because that returns false, it builds the association path for returning ingredients and tries to fetch the ingredients from the server, which is not a valid endpoint.  If we add @parent.attributes.empty?  to the beginning of our if statement, it will recognize that this the recipe is a blank object, and just add an empty association to the recipe.
